### PR TITLE
support Buffer as arguments

### DIFF
--- a/examples/basic_example.js
+++ b/examples/basic_example.js
@@ -7,11 +7,12 @@ function assert(condition) {
 
 console.log('Starting engine');
 let config = {"path":"/dev/shm", "size":1073741824};
-const db = new Database('vsmap', config);
+const db = new Database('vsmap', config, 'String');
 
-console.log('Putting new key');
+console.log('Putting new keys');
 try{
     db.put('key1', 'value1');
+    db.put('key2', Buffer.from('value2'));
     assert(db.count_all === 1);
 }
 catch(e){
@@ -19,13 +20,37 @@ catch(e){
         console.log(e.message);
 }
 
-console.log('Reading key back');
+console.log('Reading keys back');
 assert(db.get('key1') === 'value1');
+db.get_as_buffer('key2', (v) => {
+    assert(v.toString() === 'value2');
+});
 
 console.log('Iterating existing keys');
-db.put('key2', 'value2');
 db.put('key3', 'value3');
+db.put('key4', 'value4');
 db.get_keys((k) => console.log(`  visited: ${k}`));
+
+console.log('Iterating keys above');
+db.get_keys_above('key2', (k) => console.log(`  visited: ${k}`));
+
+console.log('Iterating keys below');
+db.get_keys_below('key2', (k) => console.log(`  visited: ${k}`));
+
+console.log('Iterating keys between');
+db.get_keys_between('key2', 'key4', (k) => console.log(`  visited: ${k}`));
+
+console.log('Iterating key-value pairs');
+db.get_all((k, v) => console.log(`  visited: (${k}, ${v})`));
+
+console.log('Iterating key-value pairs above');
+db.get_above('key2', (k, v) => console.log(`  visited: (${k}, ${v})`));
+
+console.log('Iterating key-value pairs below');
+db.get_below('key2', (k, v) => console.log(`  visited: (${k}, ${v})`));
+
+console.log('Iterating key-value pairs between');
+db.get_between('key2', 'key4', (k, v) => console.log(`  visited: (${k}, ${v})`));
 
 console.log('Removing existing key');
 db.remove('key1');

--- a/lib/database.h
+++ b/lib/database.h
@@ -37,6 +37,8 @@
 #include <libpmemkv.hpp>
 #include <napi.h>
 
+enum KeyType {KEY_TYPE_STRING, KEY_TYPE_BUFFER};
+
 class db : public Napi::ObjectWrap<db> {
   public:
     static Napi::Object init(Napi::Env env, Napi::Object exports);
@@ -55,15 +57,21 @@ class db : public Napi::ObjectWrap<db> {
     Napi::Value count_below(const Napi::CallbackInfo& info);
     Napi::Value count_between(const Napi::CallbackInfo& info);
     Napi::Value get_all(const Napi::CallbackInfo& info);
+    Napi::Value get_all_as_buffer(const Napi::CallbackInfo& info);
     Napi::Value get_above(const Napi::CallbackInfo& info);
+    Napi::Value get_above_as_buffer(const Napi::CallbackInfo& info);
     Napi::Value get_below(const Napi::CallbackInfo& info);
+    Napi::Value get_below_as_buffer(const Napi::CallbackInfo& info);
     Napi::Value get_between(const Napi::CallbackInfo& info);
+    Napi::Value get_between_as_buffer(const Napi::CallbackInfo& info);
     Napi::Value exists(const Napi::CallbackInfo& info);
     Napi::Value get(const Napi::CallbackInfo& info);
+    Napi::Value get_as_buffer(const Napi::CallbackInfo& info);
     Napi::Value put(const Napi::CallbackInfo& info);
     Napi::Value remove(const Napi::CallbackInfo& info);
 
     pmem::kv::db _db;
+    KeyType _key_type;
 };
 
 #endif

--- a/lib/database.js
+++ b/lib/database.js
@@ -43,6 +43,18 @@
 
 const pmemkv = require('bindings')('pmemkv');
 
+const immutable_buffer_proxy_handler = {
+	set(target, prop, value){
+		if (isNaN(prop)) {
+			target[prop] = value;
+		}
+	},
+	get(target, prop){
+		if (typeof(target[prop]) == 'function') return target[prop].bind(target);
+		return target[prop];
+	}
+};
+
 /** @class Main Node.js pmemkv class, it provides functions to operate on data in database.
  *		If an error/exception is thrown from a method it will contain *status* variable.
  *		Possible statuses are enumerated in constants.status.
@@ -55,11 +67,15 @@ class db {
 	 * @throws {Error} on any failure.
 	 * @param {string} engine Name of the engine to work with.
 	 * @param {object} config JSON like config with parameters specified for the engine.
+	 * @param {string} key_type Type of the key. Should be either "String" or "Buffer".
+	 * 		When a database is created with key of certain type it should NOT be reopened later using different key type.
 	 */
-	constructor(engine, config) {
+	constructor(engine, config, key_type='String') {
 		this._stopped = false;
-		this._db = new pmemkv.db(engine, config);
+		this._db = new pmemkv.db(engine, config, key_type);
+		this._key_type = key_type;
 		Object.defineProperty(this, '_db', {configurable: false, writable: false});
+		Object.defineProperty(this, '_key_type', {configurable: false, writable: false});
 	}
 
 	/**
@@ -83,15 +99,32 @@ class db {
 	}
 
 	/**
-	 * Executes function for every record stored in db. Callback is called
+	 * Returns value of *key_type* property.
+	 *
+	 * @return {string} Type of the key. Should be either "String" or "Buffer"
+	 */
+	get key_type() {
+		return this._key_type;
+	}
+
+	/**
+	 * Executes function for every record stored in db.Callback is called
 	 *	only with the key of each record.
 	 *
 	 * @throws {Error} on any failure.
 	 * @param {Function} callback - function to be called for every element stored in db.
 	 *		It has only one param - key (for each returned element).
+	 *		Type of the key is consistent with _key_type.
 	 */
 	get_keys(callback) {
-		this._db.get_keys(callback);
+		if (this._key_type == 'String'){
+			this._db.get_keys(callback);
+		}
+		else {
+			this._db.get_keys((k) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler));
+			})
+		}
 	}
 
 	/**
@@ -99,12 +132,20 @@ class db {
 	 *	than the given *key*. Callback is called only with the key of each record.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - sets the lower bound for querying.
+	 * @param {string|Buffer} key - sets the lower bound for querying.
 	 * @param {Function} callback - function to be called for each returned element.
 	 *		It has only one param - key (for each returned element).
+	 *		Type of the key is consistent with _key_type.
 	 */
 	get_keys_above(key, callback) {
-		this._db.get_keys_above(key, callback);
+		if (this._key_type == 'String'){
+			this._db.get_keys_above(key, callback);
+		}
+		else {
+			this._db.get_keys_above(key, (k) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler));
+			})
+		}
 	}
 
 	/**
@@ -112,12 +153,20 @@ class db {
 	 *	the given *key*. Callback is called only with the key of each record.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - sets the upper bound for querying.
+	 * @param {string|Buffer} key - sets the upper bound for querying.
 	 * @param {Function} callback - function to be called for each returned element.
 	 *		It has only one param - key (for each returned element).
+	 *		Type of the key is consistent with _key_type.
 	 */
 	get_keys_below(key, callback) {
-		this._db.get_keys_below(key, callback);
+		if (this._key_type == 'String'){
+			this._db.get_keys_below(key, callback);
+		}
+		else {
+			this._db.get_keys_below(key, (k) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler));
+			})
+		}
 	}
 
 	/**
@@ -126,13 +175,21 @@ class db {
 	 *	called only with the key of each record.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key1 - sets the lower bound for querying.
-	 * @param {string} key2 - sets the upper bound for querying.
+	 * @param {string|Buffer} key1 - sets the lower bound for querying.
+	 * @param {string|Buffer} key2 - sets the upper bound for querying.
 	 * @param {Function} callback - function to be called for each returned element.
 	 *		It has only one param - key (for each returned element).
+	 *		Type of the key is consistent with _key_type.
 	 */
 	get_keys_between(key1, key2, callback) {
-		this._db.get_keys_between(key1, key2, callback);
+		if (this._key_type == 'String'){
+			this._db.get_keys_between(key1, key2, callback);
+		}
+		else {
+			this._db.get_keys_between(key1, key2, (k) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler));
+			})
+		}
 	}
 
 	/**
@@ -151,7 +208,7 @@ class db {
 	 *	greater than the given *key*.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - sets the lower bound of counting.
+	 * @param {string|Buffer} key - sets the lower bound of counting.
 	 * @return {number|object} Number of records in db matching query
 	 *	or empty Value() if error occurred.
 	 */
@@ -164,7 +221,7 @@ class db {
 	 *	less than the given *key*.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - sets the upper bound of counting.
+	 * @param {string|Buffer} key - sets the upper bound of counting.
 	 * @return {number|object} Number of records in db matching query
 	 *	or empty Value() if error occurred.
 	 */
@@ -177,8 +234,8 @@ class db {
 	 *	greater than the *key1* and less than the *key2*.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key1 - sets the lower bound of counting.
-	 * @param {string} key2 - sets the upper bound of counting.
+	 * @param {string|Buffer} key1 - sets the lower bound of counting.
+	 * @param {string|Buffer} key2 - sets the upper bound of counting.
 	 * @return {number|object} Number of records in db matching query
 	 *	or empty Value() if error occurred.
 	 */
@@ -188,56 +245,200 @@ class db {
 
 	/**
 	 * Executes function for every record stored in db.
+	 * The value of record is returned as string.
 	 *
 	 * @throws {Error} on any failure.
 	 * @param {Function} callback - function to be called for every element stored in db.
+	 *		It has two params - key and value (for each returned element).
+	 *		Type of the key is consistent with _key_type.
+	 *		Type of the value is String.
 	 */
 	get_all(callback) {
-		this._db.get_all(callback)
+		if (this._key_type == 'String'){
+			this._db.get_all(callback);
+		}
+		else {
+			this._db.get_all((k, v) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler), v);
+			});
+		}
+	}
+
+	/**
+	 * Executes function for every record stored in db.
+	 * The value of record is returned as buffer.
+	 *
+	 * @throws {Error} on any failure.
+	 * @param {Function} callback - function to be called for every element stored in db.
+	 *		It has two params - key and value (for each returned element).
+	 *		Type of the key is consistent with _key_type.
+	 *		Type of the value is Buffer.
+	 */
+	get_all_as_buffer(callback) {
+		if (this._key_type == 'String'){
+			this._db.get_all_as_buffer((k, v) => {
+				let proxy = new Proxy(v, immutable_buffer_proxy_handler);
+				callback(k, proxy);
+			});
+		}
+		else {
+			this._db.get_all_as_buffer((k, v) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler), new Proxy(v, immutable_buffer_proxy_handler));
+			});
+		}
 	}
 
 	/**
 	 * Executes function for every record stored in db, whose keys are
 	 *	greater than the given *key*.
+	 * The value of record is returned as string.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - sets the lower bound for querying.
+	 * @param {string|Buffer} key - sets the lower bound for querying.
 	 * @param {Function} callback - function to be called for each returned element.
+	 *		It has two params - key and value (for each returned element).
+	 *		Type of the key is consistent with _key_type.
+	 *		Type of the value is String.
 	 */
 	get_above(key, callback) {
-		this._db.get_above(key, callback)
+		if (this._key_type == 'String'){
+			this._db.get_above(key, callback);
+		}
+		else {
+			this._db.get_above(key, (k, v) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler), v);
+			});
+		}
+	}
+
+	/**
+	 * Executes function for every record stored in db, whose keys are
+	 *	greater than the given *key*.
+	 * The value of record is returned as buffer.
+	 *
+	 * @throws {Error} on any failure.
+	 * @param {string|Buffer} key - sets the lower bound for querying.
+	 * @param {Function} callback - function to be called for each returned element.'
+	 *		It has two params - key and value (for each returned element).
+	 *		Type of the key is consistent with _key_type.
+	 *		Type of the value is Buffer.
+	 */
+	get_above_as_buffer(key, callback) {
+		if (this._key_type == 'String'){
+			this._db.get_above_as_buffer(key, (k, v) => {
+				callback(k, new Proxy(v, immutable_buffer_proxy_handler));
+			});
+		}
+		else {
+			this._db.get_above_as_buffer(key, (k, v) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler), new Proxy(v, immutable_buffer_proxy_handler));
+			});
+		}
 	}
 
 	/**
 	 * Executes function for every record stored in db, whose keys are
 	 *	less than the given *key*.
+	 * The value of record is returned as string.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - sets the upper bound for querying.
+	 * @param {string|Buffer} key - sets the upper bound for querying.
 	 * @param {Function} callback - function to be called for each returned element.
+	 *		It has two params - key and value (for each returned element).
+	 *		Type of the key is consistent with _key_type.
+	 *		Type of the value is String.
 	 */
 	get_below(key, callback) {
-		this._db.get_below(key, callback)
+		if (this._key_type == 'String'){
+			this._db.get_below(key, callback);
+		}
+		else {
+			this._db.get_below(key, (k, v) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler), v);
+			});
+		}
+	}
+
+	/**
+	 * Executes function for every record stored in db, whose keys are
+	 *	less than the given *key*.
+	 * The value of record is returned as buffer.
+	 * 
+	 * @throws {Error} on any failure.
+	 * @param {string|Buffer} key - sets the upper bound for querying.
+	 * @param {Function} callback - function to be called for each returned element.
+	 *		It has two params - key and value (for each returned element).
+	 *		Type of the key is consistent with _key_type.
+	 *		Type of the value is Buffer.
+	 */
+	get_below_as_buffer(key, callback) {
+		if (this._key_type == 'String'){
+			this._db.get_below_as_buffer(key, (k, v) => {
+				callback(k, new Proxy(v, immutable_buffer_proxy_handler));
+			});
+		}
+		else {
+			this._db.get_below_as_buffer(key, (k, v) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler), new Proxy(v, immutable_buffer_proxy_handler));
+			});
+		}
 	}
 
 	/**
 	 * Executes function for every record stored in db, whose keys are
 	 *	greater than the *key1* and less than the *key2*.
+	 * The value of record is returned as string.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key1 - sets the lower bound for querying.
-	 * @param {string} key2 - sets the upper bound for querying.
+	 * @param {string|Buffer} key1 - sets the lower bound for querying.
+	 * @param {string|Buffer} key2 - sets the upper bound for querying.
 	 * @param {Function} callback - function to be called for each returned element.
+	 *		It has two params - key and value (for each returned element).
+	 *		Type of the key is consistent with _key_type.
+	 *		Type of the value is String.
 	 */
 	get_between(key1, key2, callback) {
-		this._db.get_between(key1, key2, callback)
+		if (this._key_type == 'String'){
+			this._db.get_between(key1, key2, callback);
+		}
+		else {
+			this._db.get_between(key1, key2, (k, v) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler), v);
+			});
+		}
+	}
+
+	/**
+	 * Executes function for every record stored in db, whose keys are
+	 *	greater than the *key1* and less than the *key2*.
+	 * The value of record is returned as buffer.
+	 *
+	 * @throws {Error} on any failure.
+	 * @param {string|Buffer} key1 - sets the lower bound for querying.
+	 * @param {string|Buffer} key2 - sets the upper bound for querying.
+	 * @param {Function} callback - function to be called for each returned element.
+	 *		It has two params - key and value (for each returned element).
+	 *		Type of the key is consistent with _key_type.
+	 *		Type of the value is Buffer.
+	 */
+	get_between_as_buffer(key1, key2, callback) {
+		if (this._key_type == 'String'){
+			this._db.get_between_as_buffer(key1, key2, (k, v) => {
+				callback(k, new Proxy(v, immutable_buffer_proxy_handler));
+			});
+		}
+		else {
+			this._db.get_between_as_buffer(key1, key2, (k, v) => {
+				callback(new Proxy(k, immutable_buffer_proxy_handler), new Proxy(v, immutable_buffer_proxy_handler));
+			});
+		}
 	}
 
 	/**
 	 * Checks existence of record with given *key*.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - record's key to query for.
+	 * @param {string|Buffer} key - record's key to query for.
 	 * @return {boolean} True if record with given key exists, False otherwise.
 	 */
 	exists(key) {
@@ -246,9 +447,10 @@ class db {
 
 	/**
 	 * Gets value of record with given *key*.
+	 * The value of record is returned as buffer.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - record's key to query for.
+	 * @param {string|Buffer} key - record's key to query for.
 	 * @return {object} string with value stored for this key,
 	 *	env.Undefined() if not found, or empty Value() if error.
 	 */
@@ -256,12 +458,29 @@ class db {
 		return this._db.get(key);
 	}
 
+
+	/**
+	 * Gets value of record with given *key*.
+	 * The value of record is returned as buffer.
+	 *
+	 * @throws {Error} on any failure.
+	 * @param {string|Buffer} key - record's key to query for.
+	 * @param {Function} callback - function to be called for the returned element.
+	 *		It has only one param - value (for the returned element).
+	 *		Type of the value is Buffer.
+	 */
+	get_as_buffer(key, callback) {
+		this._db.get_as_buffer(key, (v) => {
+			callback(new Proxy(v, immutable_buffer_proxy_handler));
+		});
+	}
+
 	/**
 	 * Inserts a key-value pair into pmemkv database.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - record's key; record will be put into database under its name.
-	 * @param {string} value - data to be inserted into this new database record.
+	 * @param {string|Buffer} key - record's key; record will be put into database under its name.
+	 * @param {string|Buffer} value - data to be inserted into this new database record.
 	 */
 	put(key, value) {
 		this._db.put(key, value);
@@ -271,7 +490,7 @@ class db {
 	 * Removes from database record with given *key*.
 	 *
 	 * @throws {Error} on any failure.
-	 * @param {string} key - record's key to query for, to be removed.
+	 * @param {string|Buffer} key - record's key to query for, to be removed.
 	 * @return {boolean} True if pmemkv returned status OK, False if status NOT_FOUND.
 	 */
 	remove(key) {


### PR DESCRIPTION
support Node.js Buffer as arguments
    db.put(key_buf, value_buf);
    db.get(key_buf); // return a Buffer

constructing a Buffer is faster than constructing a JS String in C++ layer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-nodejs/49)
<!-- Reviewable:end -->
